### PR TITLE
make it as simple as possible

### DIFF
--- a/server.sh
+++ b/server.sh
@@ -1,16 +1,2 @@
-#!/bin/bash
-
-trap "echo Exited!; exit;" SIGINT SIGTERM
-
-PORT="${1:-1337}"
-
-main () {
-    echo "Starting..."
-
-    while true 
-    do
-        printf 'HTTP/1.1 200 OK\n\n%s' "$(cat index.html)" | nc -c -l ${PORT}
-    done
-}
-
-main
+#!/bin/sh
+printf 'HTTP/1.1 200 OK\n\n%s' "$(cat index.html)" | nc -c -l ${1:-1337}


### PR DESCRIPTION
the fact that this is bash is confusing, this script doesn't use any bashisms, so i switched it to (POSIX) sh

the trap had really no purpose that i saw.
the while true loop can be substituted for `while :; do done`.
at this point this entire thing can just turn into an alias now.

but what was the while loop for? it can allow the script to exit on if `nc` had failed.
this script is also not a very good webserver as it doesn't check if `index.html` has changed, since `index.html` is piped through `nc`.

this 'project' can now be changed to `httpsh` or `shhttp`